### PR TITLE
Fix build include path and tensor filled signature

### DIFF
--- a/grad/__init__.py
+++ b/grad/__init__.py
@@ -1,0 +1,1 @@
+# Micrograd package

--- a/grad/tensor.py
+++ b/grad/tensor.py
@@ -343,7 +343,6 @@ class Tensor:
         dtype: DTypeLike = dtypes.float32,
         device: str = "cpu",
         requires_grad: Optional[bool] = None,
-        w,
     ) -> Tensor:
         """Internal method for creating tensors filled with a value."""
         inst: Tensor = cls.__new__(cls)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ ext_modules = [
     Extension(
         "grad.kernels.cpu_kernel",
         ["./kernels/cpu_kernel.cpp"],
-        include_dirs=[pybind11.get_include(), "/opt/homebrew/include/eigen3"],
+        include_dirs=[
+            pybind11.get_include(),
+            "/opt/homebrew/include/eigen3",
+            "/usr/include/eigen3",
+        ],
         language="c++",
         extra_compile_args=extra_compile_args,
     ),


### PR DESCRIPTION
## Summary
- fix Eigen include path in `setup.py`
- remove unused argument from `Tensor._filled`
- add package marker for `grad`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'grad.tensor')*

------
https://chatgpt.com/codex/tasks/task_e_683fcb56b674832abf7bd38fcaa46630