### PR TITLE
Add basic CPU kernel tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 import pybind11
 from setuptools import Extension, find_packages, setup
@@ -14,7 +15,7 @@ ext_modules = [
     Extension(
         "grad.kernels.cpu_kernel",
         ["./kernels/cpu_kernel.cpp"],
-        include_dirs=[pybind11.get_include(), "/opt/homebrew/include/eigen3"],
+        include_dirs=[pybind11.get_include(), os.environ.get("EIGEN3_INCLUDE_DIR", "/usr/include/eigen3")],
         language="c++",
         extra_compile_args=extra_compile_args,
     ),

--- a/tests/kernels/test_cpu_kernel.py
+++ b/tests/kernels/test_cpu_kernel.py
@@ -1,0 +1,23 @@
+import pytest
+from grad.kernels import cpu_kernel
+
+
+def test_buffer_size():
+    buf = cpu_kernel.Buffer("float32", 5)
+    assert buf.size() == 5
+
+
+def test_set_and_get():
+    buf = cpu_kernel.Buffer("float32", 1)
+    buf[0] = 42.0
+    assert buf[0] == pytest.approx(42.0)
+
+
+def test_get_dtype():
+    buf = cpu_kernel.Buffer("float32", 1)
+    assert buf.get_dtype() == "float32"
+
+
+def test_invalid_dtype():
+    with pytest.raises(RuntimeError):
+        cpu_kernel.Buffer("invalid", 1)


### PR DESCRIPTION
## Summary
- fix build path for Eigen so setup works on Linux
- add simple pytest suite for cpu_kernel Buffer class

## Testing
- `pytest -q tests/kernels/test_cpu_kernel.py`
- `pytest -q` *(fails: Tensor._filled() missing required argument)*

------
https://chatgpt.com/codex/tasks/task_e_683fd5586684832a9b9a23e174bdcaca