### PR TITLE
Implement buffer sharing with tests

### DIFF
--- a/grad/buffer.py
+++ b/grad/buffer.py
@@ -13,6 +13,24 @@ class Buffer:
         self.dtype: DType = to_dtype(dtype)
         self._storage = cpu_kernel.Buffer(iterable, self.dtype.fmt)
 
+    # --- Shared storage helpers -------------------------------------------------
+    def share(self) -> "Buffer":
+        """Return a new :class:`Buffer` instance that shares the underlying
+        storage with ``self``.  The returned object is a lightweight wrapper
+        around the same C++ buffer so mutations on either instance will be
+        visible to the other."""
+
+        new = self.__class__.__new__(self.__class__)
+        new.dtype = self.dtype
+        new._storage = self._storage
+        return new
+
+    def shares_storage_with(self, other: "Buffer") -> bool:
+        """Return ``True`` if ``self`` and ``other`` refer to the same
+        underlying storage."""
+
+        return self._storage is getattr(other, "_storage", None)
+
     def to(self, device: Device): ...  # noqa: E704
 
     def __len__(self):
@@ -35,16 +53,26 @@ class Buffer:
 
     def clone(self) -> "Buffer":
         """Create a copy of this buffer"""
-        ...
+        copied = self.to_list()
+        return Buffer(self.dtype, copied)
 
     def resize(self, new_size: int) -> "Buffer":
         """Create a new buffer with different size, preserving existing data where possible"""
-        ...
+        current = self.to_list()
+        if new_size > len(current):
+            current.extend([0] * (new_size - len(current)))
+        else:
+            current = current[:new_size]
+        return Buffer(self.dtype, current)
 
     @classmethod
     def _filled(
         cls: type["Buffer"], dtype: DTypeLike, num_elem: int, val: int | float
-    ) -> "Buffer": ...
+    ) -> "Buffer":
+        inst: "Buffer" = cls.__new__(cls)
+        inst.dtype = to_dtype(dtype)
+        inst._storage = cpu_kernel.Buffer([val for _ in range(num_elem)], inst.dtype.fmt)
+        return inst
 
     def __getitem__(self, idx: int):
         return self._storage[idx]

--- a/grad/tensor.py
+++ b/grad/tensor.py
@@ -343,7 +343,6 @@ class Tensor:
         dtype: DTypeLike = dtypes.float32,
         device: str = "cpu",
         requires_grad: Optional[bool] = None,
-        w,
     ) -> Tensor:
         """Internal method for creating tensors filled with a value."""
         inst: Tensor = cls.__new__(cls)
@@ -372,7 +371,7 @@ class Tensor:
         result.device = self.device
         result.requires_grad = self.requires_grad
         result.grad, result.grad_fn, result._contiguous = None, None, False
-        result.storage = self.storage
+        result.storage = None if self.storage is None else self.storage.share()
         result.base_offset = 0 if base_offset is None else base_offset
         return result
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,1 +1,38 @@
 
+import pytest
+
+from grad.buffer import Buffer
+from grad.dtype import dtypes
+
+
+class TestBufferSharing:
+    def test_share_reflects_changes(self):
+        buf_a = Buffer(dtypes.int32, [1, 2, 3])
+        buf_b = buf_a.share()
+
+        assert buf_a.shares_storage_with(buf_b)
+        buf_b[1] = 99
+        assert buf_a[1] == 99
+
+    def test_clone_independent(self):
+        buf_a = Buffer(dtypes.int32, [1, 2, 3])
+        buf_b = buf_a.clone()
+
+        assert not buf_a.shares_storage_with(buf_b)
+        buf_b[0] = 42
+        assert buf_a[0] == 1
+
+
+class TestTensorViewSharing:
+    def test_view_shares_buffer(self):
+        from grad.tensor import Tensor
+
+        t = Tensor([1, 2, 3, 4], dtype=dtypes.int32)
+        v = t.view(2, 2)
+
+        assert t.storage is not v.storage  # different Buffer objects
+        assert t.storage is not None and v.storage is not None
+        assert t.storage.shares_storage_with(v.storage)
+        v.storage[0] = 10
+        assert t.storage[0] == 10
+


### PR DESCRIPTION
## Summary
- add share() and shares_storage_with() to Buffer
- implement clone/resize and factory method
- have tensor views use shared buffers
- test new Buffer features

## Testing
- `python -m pytest tests/test_buffer.py -q`
- `python -m pytest -q` *(fails: AttributeError in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68472c1f39a8832a84106fe72bc3f3be