### PR TITLE
Add shared Buffer storage

### DIFF
--- a/grad/buffer.py
+++ b/grad/buffer.py
@@ -21,6 +21,17 @@ class Buffer:
     def __repr__(self) -> str:
         return str(self.to_list())
 
+    def share(self) -> "Buffer":
+        """Return a new Buffer instance that shares underlying storage."""
+        new_buff = Buffer.__new__(Buffer)
+        new_buff.dtype = self.dtype
+        new_buff._storage = self._storage
+        return new_buff
+
+    def shares_storage_with(self, other: "Buffer") -> bool:
+        """Check if this buffer shares its storage with ``other``."""
+        return self._storage is getattr(other, "_storage", None)
+
     def iterstorage(self) -> Iterable[Any]:
         for i in range(self.__len__()):
             yield self._storage[i]
@@ -35,11 +46,16 @@ class Buffer:
 
     def clone(self) -> "Buffer":
         """Create a copy of this buffer"""
-        ...
+        return Buffer(self.dtype, self.to_list())
 
     def resize(self, new_size: int) -> "Buffer":
         """Create a new buffer with different size, preserving existing data where possible"""
-        ...
+        current_data = self.to_list()
+        if new_size > len(current_data):
+            current_data.extend([0] * (new_size - len(current_data)))
+        else:
+            current_data = current_data[:new_size]
+        return Buffer(self.dtype, current_data)
 
     @classmethod
     def _filled(cls, dtype: DTypeLike, num_elem: int, val: int | float) -> "Buffer":
@@ -58,4 +74,4 @@ class Buffer:
 
     def size_bytes(self) -> int:
         """Return the size of this buffer in bytes"""
-        ...
+        return len(self) * self.dtype.itemsize

--- a/grad/tensor.py
+++ b/grad/tensor.py
@@ -367,7 +367,7 @@ class Tensor:
         result.device = self.device
         result.requires_grad = self.requires_grad
         result.grad, result.grad_fn, result._contiguous = None, None, False
-        result.storage = self.storage
+        result.storage = self.storage.share() if self.storage is not None else None
         result.base_offset = 0 if base_offset is None else base_offset
         return result
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -139,3 +139,19 @@ class TestBuffer:
         assert len(recovered) == len(original)
         for orig, rec in zip(original, recovered):
             assert abs(orig - rec) < 1e-5
+
+    def test_share_and_clone(self):
+        b = Buffer("float32", [1.0, 2.0, 3.0])
+        shared = b.share()
+        assert shared.to_list() == [1.0, 2.0, 3.0]
+        assert b.shares_storage_with(shared)
+
+        shared[0] = 10.0
+        # modifying shared should reflect in original
+        assert b[0] == 10.0
+
+        clone = b.clone()
+        assert not clone.shares_storage_with(b)
+        clone[1] = -5.0
+        # original unaffected
+        assert b[1] != -5.0


### PR DESCRIPTION
## Summary
- implement sharing/cloning logic for Buffer
- update Tensor views to use Buffer.share
- add tests for Buffer.share and clone

## Testing
- `pre-commit run --files grad/buffer.py grad/tensor.py tests/test_buffer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'grad.kernels.cpu_kernel')*

------
https://chatgpt.com/codex/tasks/task_e_68473f72bd00832aa374a099f0df693c