### PR TITLE
Add buffer member gtests

### DIFF
--- a/kernels/cpu_kernel.cpp
+++ b/kernels/cpu_kernel.cpp
@@ -233,6 +233,20 @@ py::object Buffer::get_item(size_t index) const {
       data_);
 }
 
+py::object Buffer::set_item(size_t index, py::object val) const {
+  if (index >= size()) {
+    throw std::out_of_range("Buffer index out of range");
+  }
+
+  std::visit(
+      [&](auto &b) {
+        using DestType = std::decay_t<decltype(b[0])>;
+        const_cast<DestType &>(b[index]) = val.cast<DestType>();
+      },
+      const_cast<BufferVariant &>(data_));
+  return val;
+}
+
 // -----------------------------------------------------------------------------
 PYBIND11_MODULE(cpu_kernel, m) {
   py::class_<Buffer>(m, "Buffer")

--- a/kernels/cpu_kernel.h
+++ b/kernels/cpu_kernel.h
@@ -97,6 +97,20 @@ private:
   DType dtype_;
 };
 
+template <typename T>
+inline void Buffer::set_item(size_t index, T value) {
+  if (index >= size()) {
+    throw std::out_of_range("Buffer index out of range");
+  }
+
+  std::visit(
+      [&](auto &b) {
+        using DestType = std::decay_t<decltype(b[0])>;
+        b[index] = static_cast<DestType>(value);
+      },
+      data_);
+}
+
 // Buffer add(const Buffer &lhs, const Buffer &rhs,
 //            const std::vector<std::size_t> &lhs_shape,
 //            const std::vector<std::size_t> &rhs_shape,

--- a/tests/kernels/CMakeLists.txt
+++ b/tests/kernels/CMakeLists.txt
@@ -58,3 +58,14 @@ target_link_libraries(test_dtype_enum gtest_main
 # Ensure IEEE 754 compliance in tests
 target_compile_options(test_dtype_enum PRIVATE -fno-fast-math)
 gtest_discover_tests(test_dtype_enum)
+
+# Build Buffer member tests
+add_executable(test_buffer_members test_buffer_members.cpp)
+target_include_directories(test_buffer_members PRIVATE
+                        ${pybind11_SOURCE_DIR}/include
+                        ${Python3_INCLUDE_DIRS}
+                        ${XSIMD_INCLUDE_DIR})
+target_link_libraries(test_buffer_members gtest_main
+                    cpu_kernel_lib ${Python3_LIBRARIES})
+target_compile_options(test_buffer_members PRIVATE -fno-fast-math)
+gtest_discover_tests(test_buffer_members)

--- a/tests/kernels/test_buffer_members.cpp
+++ b/tests/kernels/test_buffer_members.cpp
@@ -1,0 +1,56 @@
+#include "../../kernels/cpu_kernel.h"
+#include <gtest/gtest.h>
+#include <pybind11/embed.h>
+
+namespace py = pybind11;
+
+TEST(BufferMembersTest, RoundTripAndBounds) {
+  py::scoped_interpreter guard{};
+
+  Buffer fbuf(2, "float32");
+  fbuf.set_item<float>(0, 1.25f);
+  fbuf.set_item<float>(1, -2.5f);
+  EXPECT_FLOAT_EQ(py::cast<float>(fbuf.get_item(0)), 1.25f);
+  EXPECT_FLOAT_EQ(py::cast<float>(fbuf.get_item(1)), -2.5f);
+  EXPECT_THROW(fbuf.get_item(2), std::out_of_range);
+  EXPECT_THROW(fbuf.set_item<float>(2, 0.f), std::out_of_range);
+
+  Buffer ibuf(1, "int32");
+  ibuf.set_item<int32_t>(0, 42);
+  EXPECT_EQ(py::cast<int32_t>(ibuf.get_item(0)), 42);
+}
+
+TEST(BufferMembersTest, ReprContainsInfo) {
+  py::scoped_interpreter guard{};
+  Buffer buf(3, "int64");
+  std::string r = buf.repr();
+  EXPECT_NE(r.find("dtype=int64"), std::string::npos);
+  EXPECT_NE(r.find("size=3"), std::string::npos);
+}
+
+TEST(BufferMembersTest, ArrayInterfaceBasics) {
+  py::scoped_interpreter guard{};
+  Buffer buf(5, "float32");
+  auto ai = buf.array_interface();
+  EXPECT_EQ(ai["shape"].cast<py::tuple>()[0].cast<std::size_t>(), 5);
+  EXPECT_EQ(ai["typestr"].cast<std::string>(), "<f4");
+
+  Buffer ibuf(2, "int32");
+  auto ai2 = ibuf.array_interface();
+  EXPECT_EQ(ai2["typestr"].cast<std::string>(), "<i4");
+}
+
+TEST(BufferMembersTest, CastBetweenTypes) {
+  py::scoped_interpreter guard{};
+  Buffer fbuf({1.5f, -2.0f}, "float32");
+  Buffer ibuf = fbuf.cast("int32");
+  EXPECT_EQ(py::cast<int32_t>(ibuf.get_item(0)), static_cast<int32_t>(1.5f));
+  EXPECT_EQ(py::cast<int32_t>(ibuf.get_item(1)), static_cast<int32_t>(-2.0f));
+
+  Buffer i64buf({1, 2, 3}, "int64");
+  Buffer f64buf = i64buf.cast("float64");
+  EXPECT_DOUBLE_EQ(py::cast<double>(f64buf.get_item(0)), 1.0);
+  EXPECT_DOUBLE_EQ(py::cast<double>(f64buf.get_item(1)), 2.0);
+  EXPECT_DOUBLE_EQ(py::cast<double>(f64buf.get_item(2)), 3.0);
+}
+


### PR DESCRIPTION
## Summary
- implement missing `Buffer::set_item` functionality
- add comprehensive tests for `Buffer` members

## Testing
- `./run_cpp_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68599f6979fc832a84399b989350bba4